### PR TITLE
Add global analysis context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { AnalysisProvider } from './contexts/AnalysisContext';
 import LandingPage from './pages/LandingPage';
 import AnalyzePage from './pages/AnalyzePage';
 import PreviewPage from './pages/PreviewPage';
@@ -12,8 +13,9 @@ import EditProfile from './pages/EditProfile';
 function App() {
   return (
     <ThemeProvider>
-      <Router>
-        <Routes>
+      <AnalysisProvider>
+        <Router>
+          <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/analyze" element={<AnalyzePage />} />
           <Route path="/results" element={<ResultsPage />} />
@@ -22,8 +24,9 @@ function App() {
           <Route path="/history" element={<History />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/edit-profile" element={<EditProfile />} />
-        </Routes>
-      </Router>
+          </Routes>
+        </Router>
+      </AnalysisProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/JobDescriptionInput.tsx
+++ b/src/components/JobDescriptionInput.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 // LinkedIn Icon Component
@@ -16,7 +15,6 @@ type JobDescriptionInputProps = {
 };
 
 const JobDescriptionInput: React.FC<JobDescriptionInputProps> = ({ value, onChange }) => {
-  const { theme } = useTheme();
 
   return (
     <motion.div

--- a/src/components/MatchScoreCard.tsx
+++ b/src/components/MatchScoreCard.tsx
@@ -17,7 +17,7 @@ const MatchScoreCard: React.FC = () => {
     });
 
     return animation.stop;
-  }, [score]);
+  }, [score, count]);
 
   return (
     <div className="p-4 border rounded-lg shadow-sm text-center">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, Sparkles, ChevronDown, Settings, FileText, LogOut, User, LayoutDashboard } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from './ThemeToggle';
 
@@ -17,7 +16,6 @@ const Navigation: React.FC<NavigationProps> = ({
   backTo = "/", 
   backLabel = "Back" 
 }) => {
-  const { theme } = useTheme();
   const location = useLocation();
   const [isProfileOpen, setIsProfileOpen] = useState(false);
 

--- a/src/components/ResumeUploader.tsx
+++ b/src/components/ResumeUploader.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Upload, FileText, CheckCircle } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 type ResumeUploaderProps = {
@@ -10,7 +9,6 @@ type ResumeUploaderProps = {
 };
 
 const ResumeUploader: React.FC<ResumeUploaderProps> = ({ onFileSelect, onTextChange }) => {
-  const { theme } = useTheme();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [resumeText, setResumeText] = useState('');
 

--- a/src/contexts/AnalysisContext.tsx
+++ b/src/contexts/AnalysisContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useState } from 'react';
+import { getMockMatchScore, getMockKeywords, getMockSuggestions } from '../utils/mockAnalysis';
+
+interface AnalysisContextType {
+  jobUrl: string;
+  resumeFile: File | null;
+  resumeText: string;
+  matchScore: number | null;
+  keywords: string[];
+  suggestions: string[];
+  setJobUrl: (url: string) => void;
+  setResumeFile: (file: File | null) => void;
+  setResumeText: (text: string) => void;
+  analyze: () => Promise<void>;
+}
+
+const AnalysisContext = createContext<AnalysisContextType | undefined>(undefined);
+
+export const useAnalysis = () => {
+  const ctx = useContext(AnalysisContext);
+  if (!ctx) throw new Error('useAnalysis must be used within AnalysisProvider');
+  return ctx;
+};
+
+export const AnalysisProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [jobUrl, setJobUrl] = useState('');
+  const [resumeFile, setResumeFile] = useState<File | null>(null);
+  const [resumeText, setResumeText] = useState('');
+  const [matchScore, setMatchScore] = useState<number | null>(null);
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  const analyze = async () => {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    setMatchScore(getMockMatchScore());
+    setKeywords(getMockKeywords());
+    setSuggestions(getMockSuggestions());
+  };
+
+  return (
+    <AnalysisContext.Provider
+      value={{
+        jobUrl,
+        resumeFile,
+        resumeText,
+        matchScore,
+        keywords,
+        suggestions,
+        setJobUrl,
+        setResumeFile,
+        setResumeText,
+        analyze,
+      }}
+    >
+      {children}
+    </AnalysisContext.Provider>
+  );
+};

--- a/src/pages/AnalyzePage.tsx
+++ b/src/pages/AnalyzePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Sparkles, Loader } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { useAnalysis } from '../contexts/AnalysisContext';
 import { cn } from '../lib/utils';
 import ResumeUploader from '../components/ResumeUploader';
 import JobDescriptionInput from '../components/JobDescriptionInput';
@@ -11,18 +11,20 @@ import Button from '../components/Button';
 
 const AnalyzePage: React.FC = () => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [jobUrl, setJobUrl] = useState('');
-  const [resumeFile, setResumeFile] = useState<File | null>(null);
-  const [resumeText, setResumeText] = useState('');
-  const { theme } = useTheme();
+  const {
+    jobUrl,
+    resumeFile,
+    resumeText,
+    setJobUrl,
+    setResumeFile,
+    setResumeText,
+    analyze,
+  } = useAnalysis();
   const navigate = useNavigate();
 
   const handleAnalyze = async () => {
     setIsAnalyzing(true);
-    
-    // Simulate analysis time for better UX
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
+    await analyze();
     setIsAnalyzing(false);
     navigate('/results');
   };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { 
-  User, 
-  Settings, 
-  Crown, 
-  TrendingUp, 
-  FileText, 
-  Award, 
+  Settings,
+  Crown,
+  TrendingUp,
+  FileText,
+  Award,
   Target,
   Edit3,
-  Mail,
-  Calendar,
   BarChart3,
   Zap
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -28,7 +24,7 @@ const StatCard = ({
   color,
   trend
 }: { 
-  icon: any, 
+  icon: React.ElementType,
   title: string, 
   value: string | number, 
   subtitle: string,
@@ -65,7 +61,6 @@ const StatCard = ({
 
 
 const Dashboard: React.FC = () => {
-  const { theme } = useTheme();
 
   return (
     <PageLayout showBackButton backTo="/results" backLabel="Back">

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -16,13 +16,11 @@ import {
   Upload,
   X
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
 
 const EditProfile: React.FC = () => {
-  const { theme } = useTheme();
   const [profileData, setProfileData] = useState({
     firstName: 'John',
     lastName: 'Smith',

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -14,9 +14,7 @@ import {
   Clock,
   CheckCircle,
   XCircle,
-  AlertCircle
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -228,7 +226,6 @@ const FilterDropdown = ({
 };
 
 const History: React.FC = () => {
-  const { theme } = useTheme();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [sortBy, setSortBy] = useState('date');

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { CheckCircle, Target, Zap, Sparkles, FileText, BarChart3 } from 'lucide-react';
+import { Target, Sparkles, FileText, BarChart3 } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from '../components/ThemeToggle';

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Sparkles, TrendingUp, CheckCircle, AlertCircle, Star, Download, Trophy, Target, Zap, Crown, PartyPopper } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { Sparkles, TrendingUp, CheckCircle, Star, Download, Trophy, Target, Zap, PartyPopper } from 'lucide-react';
+import { useAnalysis } from '../contexts/AnalysisContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -58,7 +57,7 @@ const StatCard = ({
   value, 
   color 
 }: { 
-  icon: any, 
+  icon: React.ElementType,
   title: string, 
   value: string | number, 
   color: string 
@@ -85,7 +84,7 @@ const StatCard = ({
 );
 
 const ResultsPage: React.FC = () => {
-  const { theme } = useTheme();
+  const { matchScore } = useAnalysis();
   const [animatedScore, setAnimatedScore] = useState(0);
 
   useEffect(() => {
@@ -180,10 +179,10 @@ const ResultsPage: React.FC = () => {
                 value="A+" 
                 color="bg-purple-500"
               />
-              <StatCard 
+              <StatCard
                 icon={CheckCircle}
-                title="ATS Score" 
-                value="98%" 
+                title="ATS Score"
+                value={matchScore !== null ? `${matchScore}%` : '--'}
                 color="bg-green-500"
               />
               <StatCard 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,7 +10,6 @@ import {
   Lock,
   Download
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -24,7 +23,7 @@ const SettingsSection = ({
   title: string, 
   description: string, 
   children: React.ReactNode,
-  icon: any
+  icon: React.ElementType
 }) => (
   <motion.div
     initial={{ opacity: 0, y: 20 }}
@@ -49,41 +48,7 @@ const SettingsSection = ({
   </motion.div>
 );
 
-const ToggleSwitch = ({ 
-  enabled, 
-  onChange, 
-  label, 
-  description 
-}: { 
-  enabled: boolean, 
-  onChange: (enabled: boolean) => void,
-  label: string,
-  description: string
-}) => (
-  <div className="flex items-center justify-between py-3">
-    <div>
-      <div className="font-medium text-zinc-900 dark:text-white">{label}</div>
-      <div className="text-sm text-zinc-600 dark:text-zinc-400">{description}</div>
-    </div>
-    <button
-      onClick={() => onChange(!enabled)}
-      className={cn(
-        "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-        enabled ? "bg-blue-600" : "bg-zinc-300 dark:bg-zinc-600"
-      )}
-    >
-      <span
-        className={cn(
-          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
-          enabled ? "translate-x-6" : "translate-x-1"
-        )}
-      />
-    </button>
-  </div>
-);
-
 const Settings: React.FC = () => {
-  const { theme } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
 
   return (


### PR DESCRIPTION
## Summary
- add `AnalysisContext` for shared resume data and results
- use the context in `AnalyzePage` and `ResultsPage`
- drop unused imports and variables to clear lint errors
- define icon prop types and remove unused helper component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843b6e4a48483338f98d398fcb194c6