### PR TITLE
Implement loading states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { LoadingProvider } from './contexts/LoadingContext';
+import LoadingOverlay from './components/LoadingOverlay';
 import LandingPage from './pages/LandingPage';
 import AnalyzePage from './pages/AnalyzePage';
 import PreviewPage from './pages/PreviewPage';
@@ -12,18 +14,21 @@ import EditProfile from './pages/EditProfile';
 function App() {
   return (
     <ThemeProvider>
-      <Router>
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/analyze" element={<AnalyzePage />} />
-          <Route path="/results" element={<ResultsPage />} />
-          <Route path="/preview" element={<PreviewPage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/history" element={<History />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/edit-profile" element={<EditProfile />} />
-        </Routes>
-      </Router>
+      <LoadingProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/analyze" element={<AnalyzePage />} />
+            <Route path="/results" element={<ResultsPage />} />
+            <Route path="/preview" element={<PreviewPage />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/history" element={<History />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/edit-profile" element={<EditProfile />} />
+          </Routes>
+          <LoadingOverlay />
+        </Router>
+      </LoadingProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/JobDescriptionInput.tsx
+++ b/src/components/JobDescriptionInput.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 // LinkedIn Icon Component
@@ -16,7 +15,6 @@ type JobDescriptionInputProps = {
 };
 
 const JobDescriptionInput: React.FC<JobDescriptionInputProps> = ({ value, onChange }) => {
-  const { theme } = useTheme();
 
   return (
     <motion.div

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Loader } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useLoading } from '../contexts/LoadingContext';
+
+const LoadingOverlay: React.FC = () => {
+  const { loading } = useLoading();
+
+  return (
+    <AnimatePresence>
+      {loading && (
+        <motion.div
+          key="loader"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        >
+          <Loader className="w-8 h-8 text-white animate-spin" />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, Sparkles, ChevronDown, Settings, FileText, LogOut, User, LayoutDashboard } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { useLoading } from '../contexts/LoadingContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from './ThemeToggle';
 
@@ -12,14 +12,24 @@ interface NavigationProps {
   backLabel?: string;
 }
 
-const Navigation: React.FC<NavigationProps> = ({ 
-  showBackButton = false, 
-  backTo = "/", 
-  backLabel = "Back" 
+const Navigation: React.FC<NavigationProps> = ({
+  showBackButton = false,
+  backTo = "/",
+  backLabel = "Back"
 }) => {
-  const { theme } = useTheme();
+  const { loading } = useLoading();
   const location = useLocation();
   const [isProfileOpen, setIsProfileOpen] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-between mb-8">
+        <div className="w-24 h-8 rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        <div className="w-32 h-8 rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        <div className="w-24 h-8 rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      </div>
+    );
+  }
 
   return (
     <motion.div

--- a/src/components/ResumeUploader.tsx
+++ b/src/components/ResumeUploader.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Upload, FileText, CheckCircle } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 type ResumeUploaderProps = {
@@ -10,7 +9,6 @@ type ResumeUploaderProps = {
 };
 
 const ResumeUploader: React.FC<ResumeUploaderProps> = ({ onFileSelect, onTextChange }) => {
-  const { theme } = useTheme();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [resumeText, setResumeText] = useState('');
 

--- a/src/contexts/LoadingContext.tsx
+++ b/src/contexts/LoadingContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface LoadingContextType {
+  loading: boolean;
+  startLoading: () => void;
+  stopLoading: () => void;
+}
+
+const LoadingContext = createContext<LoadingContextType | undefined>(undefined);
+
+export const LoadingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [loading, setLoading] = useState(false);
+
+  const startLoading = () => setLoading(true);
+  const stopLoading = () => setLoading(false);
+
+  return (
+    <LoadingContext.Provider value={{ loading, startLoading, stopLoading }}>
+      {children}
+    </LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => {
+  const context = useContext(LoadingContext);
+  if (!context) {
+    throw new Error('useLoading must be used within a LoadingProvider');
+  }
+  return context;
+};

--- a/src/pages/AnalyzePage.tsx
+++ b/src/pages/AnalyzePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Sparkles, Loader } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { useLoading } from '../contexts/LoadingContext';
 import { cn } from '../lib/utils';
 import ResumeUploader from '../components/ResumeUploader';
 import JobDescriptionInput from '../components/JobDescriptionInput';
@@ -14,16 +14,18 @@ const AnalyzePage: React.FC = () => {
   const [jobUrl, setJobUrl] = useState('');
   const [resumeFile, setResumeFile] = useState<File | null>(null);
   const [resumeText, setResumeText] = useState('');
-  const { theme } = useTheme();
+  const { startLoading, stopLoading } = useLoading();
   const navigate = useNavigate();
 
   const handleAnalyze = async () => {
     setIsAnalyzing(true);
-    
+    startLoading();
+
     // Simulate analysis time for better UX
     await new Promise(resolve => setTimeout(resolve, 2000));
-    
+
     setIsAnalyzing(false);
+    stopLoading();
     navigate('/results');
   };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { 
-  User, 
-  Settings, 
-  Crown, 
-  TrendingUp, 
-  FileText, 
-  Award, 
+  Settings,
+  Crown,
+  TrendingUp,
+  FileText,
+  Award,
   Target,
   Edit3,
-  Mail,
-  Calendar,
   BarChart3,
   Zap
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -27,10 +23,10 @@ const StatCard = ({
   subtitle,
   color,
   trend
-}: { 
-  icon: any, 
-  title: string, 
-  value: string | number, 
+}: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>,
+  title: string,
+  value: string | number,
   subtitle: string,
   color: string,
   trend?: string
@@ -65,7 +61,6 @@ const StatCard = ({
 
 
 const Dashboard: React.FC = () => {
-  const { theme } = useTheme();
 
   return (
     <PageLayout showBackButton backTo="/results" backLabel="Back">

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -16,13 +16,11 @@ import {
   Upload,
   X
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
 
 const EditProfile: React.FC = () => {
-  const { theme } = useTheme();
   const [profileData, setProfileData] = useState({
     firstName: 'John',
     lastName: 'Smith',

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -13,10 +13,8 @@ import {
   Eye,
   Clock,
   CheckCircle,
-  XCircle,
-  AlertCircle
+  XCircle
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -228,7 +226,6 @@ const FilterDropdown = ({
 };
 
 const History: React.FC = () => {
-  const { theme } = useTheme();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [sortBy, setSortBy] = useState('date');

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { CheckCircle, Target, Zap, Sparkles, FileText, BarChart3 } from 'lucide-react';
+import { Target, Sparkles, FileText, BarChart3 } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from '../components/ThemeToggle';

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Sparkles, TrendingUp, CheckCircle, AlertCircle, Star, Download, Trophy, Target, Zap, Crown, PartyPopper } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { Sparkles, TrendingUp, CheckCircle, Star, Download, Trophy, Target, Zap, PartyPopper } from 'lucide-react';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -57,11 +55,11 @@ const StatCard = ({
   title, 
   value, 
   color 
-}: { 
-  icon: any, 
-  title: string, 
-  value: string | number, 
-  color: string 
+}: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>,
+  title: string,
+  value: string | number,
+  color: string
 }) => (
   <motion.div
     initial={{ opacity: 0, y: 20 }}
@@ -85,7 +83,6 @@ const StatCard = ({
 );
 
 const ResultsPage: React.FC = () => {
-  const { theme } = useTheme();
   const [animatedScore, setAnimatedScore] = useState(0);
 
   useEffect(() => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,7 +10,6 @@ import {
   Lock,
   Download
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -24,7 +23,7 @@ const SettingsSection = ({
   title: string, 
   description: string, 
   children: React.ReactNode,
-  icon: any
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
 }) => (
   <motion.div
     initial={{ opacity: 0, y: 20 }}
@@ -49,41 +48,7 @@ const SettingsSection = ({
   </motion.div>
 );
 
-const ToggleSwitch = ({ 
-  enabled, 
-  onChange, 
-  label, 
-  description 
-}: { 
-  enabled: boolean, 
-  onChange: (enabled: boolean) => void,
-  label: string,
-  description: string
-}) => (
-  <div className="flex items-center justify-between py-3">
-    <div>
-      <div className="font-medium text-zinc-900 dark:text-white">{label}</div>
-      <div className="text-sm text-zinc-600 dark:text-zinc-400">{description}</div>
-    </div>
-    <button
-      onClick={() => onChange(!enabled)}
-      className={cn(
-        "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-        enabled ? "bg-blue-600" : "bg-zinc-300 dark:bg-zinc-600"
-      )}
-    >
-      <span
-        className={cn(
-          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
-          enabled ? "translate-x-6" : "translate-x-1"
-        )}
-      />
-    </button>
-  </div>
-);
-
 const Settings: React.FC = () => {
-  const { theme } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
 
   return (


### PR DESCRIPTION
## Summary
- add a global LoadingProvider and hook
- create a LoadingOverlay component
- wrap routing with LoadingProvider and overlay
- show navigation skeleton during loading
- trigger global loading from Analyze page
- clean up unused variables and fix type issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843b7cd78308333bcf11c8f96d864cd