### PR TITLE
Implement mock analysis state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { AnalysisProvider } from './contexts/AnalysisContext';
 import LandingPage from './pages/LandingPage';
 import AnalyzePage from './pages/AnalyzePage';
 import PreviewPage from './pages/PreviewPage';
@@ -12,8 +13,9 @@ import EditProfile from './pages/EditProfile';
 function App() {
   return (
     <ThemeProvider>
-      <Router>
-        <Routes>
+      <AnalysisProvider>
+        <Router>
+          <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/analyze" element={<AnalyzePage />} />
           <Route path="/results" element={<ResultsPage />} />
@@ -24,6 +26,7 @@ function App() {
           <Route path="/edit-profile" element={<EditProfile />} />
         </Routes>
       </Router>
+      </AnalysisProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/JobDescriptionInput.tsx
+++ b/src/components/JobDescriptionInput.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 // LinkedIn Icon Component
@@ -16,7 +15,6 @@ type JobDescriptionInputProps = {
 };
 
 const JobDescriptionInput: React.FC<JobDescriptionInputProps> = ({ value, onChange }) => {
-  const { theme } = useTheme();
 
   return (
     <motion.div

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, Sparkles, ChevronDown, Settings, FileText, LogOut, User, LayoutDashboard } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from './ThemeToggle';
 
@@ -17,7 +16,6 @@ const Navigation: React.FC<NavigationProps> = ({
   backTo = "/", 
   backLabel = "Back" 
 }) => {
-  const { theme } = useTheme();
   const location = useLocation();
   const [isProfileOpen, setIsProfileOpen] = useState(false);
 

--- a/src/components/ResumeUploader.tsx
+++ b/src/components/ResumeUploader.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Upload, FileText, CheckCircle } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 
 type ResumeUploaderProps = {
@@ -10,7 +9,6 @@ type ResumeUploaderProps = {
 };
 
 const ResumeUploader: React.FC<ResumeUploaderProps> = ({ onFileSelect, onTextChange }) => {
-  const { theme } = useTheme();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [resumeText, setResumeText] = useState('');
 

--- a/src/contexts/AnalysisContext.tsx
+++ b/src/contexts/AnalysisContext.tsx
@@ -1,0 +1,121 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface AnalysisRecord {
+  id: string;
+  company: string;
+  position: string;
+  date: string;
+  status: 'pending' | 'interviewed' | 'rejected' | 'offer';
+  score: number;
+  beforeScore: number;
+  improvement: number;
+  logo: string;
+  keywordsMatched: number;
+  totalKeywords: number;
+  readability: string;
+  atsScore: number;
+  impactFactor: number;
+}
+
+interface AnalysisContextValue {
+  analyses: AnalysisRecord[];
+  currentAnalysis: AnalysisRecord | null;
+  addAnalysis: (analysis: AnalysisRecord) => void;
+  setCurrentAnalysis: (id: string) => void;
+}
+
+const AnalysisContext = createContext<AnalysisContextValue | undefined>(undefined);
+
+export const useAnalysis = () => {
+  const ctx = useContext(AnalysisContext);
+  if (!ctx) throw new Error('useAnalysis must be used within AnalysisProvider');
+  return ctx;
+};
+
+const initialHistory: AnalysisRecord[] = [
+  {
+    id: '1',
+    company: 'Google',
+    position: 'Software Engineer',
+    date: '2024-01-10',
+    status: 'interviewed',
+    score: 92,
+    beforeScore: 65,
+    improvement: 27,
+    logo: '🅶',
+    keywordsMatched: 12,
+    totalKeywords: 12,
+    readability: 'A+',
+    atsScore: 98,
+    impactFactor: 9.2,
+  },
+  {
+    id: '2',
+    company: 'Microsoft',
+    position: 'Senior Developer',
+    date: '2024-01-08',
+    status: 'pending',
+    score: 89,
+    beforeScore: 66,
+    improvement: 23,
+    logo: 'Ⓜ️',
+    keywordsMatched: 10,
+    totalKeywords: 12,
+    readability: 'A',
+    atsScore: 91,
+    impactFactor: 8.7,
+  },
+  {
+    id: '3',
+    company: 'Apple',
+    position: 'iOS Developer',
+    date: '2024-01-05',
+    status: 'offer',
+    score: 95,
+    beforeScore: 68,
+    improvement: 31,
+    logo: '🍎',
+    keywordsMatched: 11,
+    totalKeywords: 12,
+    readability: 'A+',
+    atsScore: 97,
+    impactFactor: 9.5,
+  },
+  {
+    id: '4',
+    company: 'Meta',
+    position: 'Product Manager',
+    date: '2024-01-03',
+    status: 'rejected',
+    score: 78,
+    beforeScore: 62,
+    improvement: 15,
+    logo: 'Ⓜ️',
+    keywordsMatched: 9,
+    totalKeywords: 12,
+    readability: 'B+',
+    atsScore: 85,
+    impactFactor: 7.9,
+  },
+];
+
+export const AnalysisProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [analyses, setAnalyses] = useState<AnalysisRecord[]>(initialHistory);
+  const [currentAnalysis, setCurrent] = useState<AnalysisRecord | null>(initialHistory[0]);
+
+  const addAnalysis = (analysis: AnalysisRecord) => {
+    setAnalyses(prev => [...prev, analysis]);
+    setCurrent(analysis);
+  };
+
+  const setCurrentAnalysis = (id: string) => {
+    const found = analyses.find(a => a.id === id) || null;
+    setCurrent(found);
+  };
+
+  return (
+    <AnalysisContext.Provider value={{ analyses, currentAnalysis, addAnalysis, setCurrentAnalysis }}>
+      {children}
+    </AnalysisContext.Provider>
+  );
+};

--- a/src/pages/AnalyzePage.tsx
+++ b/src/pages/AnalyzePage.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Sparkles, Loader } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { useAnalysis } from '../contexts/AnalysisContext';
+import { createMockAnalysis } from '../utils/mockAnalysis';
 import { cn } from '../lib/utils';
 import ResumeUploader from '../components/ResumeUploader';
 import JobDescriptionInput from '../components/JobDescriptionInput';
@@ -14,7 +15,7 @@ const AnalyzePage: React.FC = () => {
   const [jobUrl, setJobUrl] = useState('');
   const [resumeFile, setResumeFile] = useState<File | null>(null);
   const [resumeText, setResumeText] = useState('');
-  const { theme } = useTheme();
+  const { addAnalysis } = useAnalysis();
   const navigate = useNavigate();
 
   const handleAnalyze = async () => {
@@ -24,6 +25,8 @@ const AnalyzePage: React.FC = () => {
     await new Promise(resolve => setTimeout(resolve, 2000));
     
     setIsAnalyzing(false);
+    const analysis = createMockAnalysis(Date.now().toString());
+    addAnalysis(analysis);
     navigate('/results');
   };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { 
-  User, 
-  Settings, 
-  Crown, 
-  TrendingUp, 
-  FileText, 
-  Award, 
+  Settings,
+  Crown,
+  TrendingUp,
+  FileText,
+  Award,
   Target,
   Edit3,
-  Mail,
-  Calendar,
   BarChart3,
   Zap
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -65,7 +61,6 @@ const StatCard = ({
 
 
 const Dashboard: React.FC = () => {
-  const { theme } = useTheme();
 
   return (
     <PageLayout showBackButton backTo="/results" backLabel="Back">

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -16,13 +16,11 @@ import {
   Upload,
   X
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
 
 const EditProfile: React.FC = () => {
-  const { theme } = useTheme();
   const [profileData, setProfileData] = useState({
     firstName: 'John',
     lastName: 'Smith',

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -13,89 +13,16 @@ import {
   Eye,
   Clock,
   CheckCircle,
-  XCircle,
-  AlertCircle
+  XCircle
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { useAnalysis } from '../contexts/AnalysisContext';
+import type { AnalysisRecord } from '../contexts/AnalysisContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
 
-interface ResumeHistory {
-  id: string;
-  company: string;
-  position: string;
-  date: string;
-  status: 'pending' | 'interviewed' | 'rejected' | 'offer';
-  score: number;
-  improvement: number;
-  logo: string;
-}
 
-const mockHistory: ResumeHistory[] = [
-  {
-    id: '1',
-    company: 'Google',
-    position: 'Software Engineer',
-    date: '2024-01-10',
-    status: 'interviewed',
-    score: 92,
-    improvement: 27,
-    logo: '🅶'
-  },
-  {
-    id: '2',
-    company: 'Microsoft',
-    position: 'Senior Developer',
-    date: '2024-01-08',
-    status: 'pending',
-    score: 89,
-    improvement: 23,
-    logo: 'Ⓜ️'
-  },
-  {
-    id: '3',
-    company: 'Apple',
-    position: 'iOS Developer',
-    date: '2024-01-05',
-    status: 'offer',
-    score: 95,
-    improvement: 31,
-    logo: '🍎'
-  },
-  {
-    id: '4',
-    company: 'Meta',
-    position: 'Product Manager',
-    date: '2024-01-03',
-    status: 'rejected',
-    score: 78,
-    improvement: 15,
-    logo: 'Ⓜ️'
-  },
-  {
-    id: '5',
-    company: 'Netflix',
-    position: 'Full Stack Engineer',
-    date: '2023-12-28',
-    status: 'interviewed',
-    score: 88,
-    improvement: 25,
-    logo: 'Ⓝ'
-  },
-  {
-    id: '6',
-    company: 'Amazon',
-    position: 'Cloud Engineer',
-    date: '2023-12-25',
-    status: 'pending',
-    score: 85,
-    improvement: 20,
-    logo: '🅰️'
-  }
-];
-
-const StatusBadge = ({ status }: { status: ResumeHistory['status'] }) => {
+const StatusBadge = ({ status }: { status: AnalysisRecord['status'] }) => {
   const statusConfig = {
     pending: {
       color: 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300',
@@ -133,7 +60,7 @@ const StatusBadge = ({ status }: { status: ResumeHistory['status'] }) => {
   );
 };
 
-const ResumeHistoryCard = ({ resume }: { resume: ResumeHistory }) => {
+const ResumeHistoryCard = ({ resume }: { resume: AnalysisRecord }) => {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -209,7 +136,7 @@ const FilterDropdown = ({
   return (
     <select
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
       className={cn(
         "px-4 py-2 rounded-lg border transition-all duration-300",
         "bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm",
@@ -228,19 +155,19 @@ const FilterDropdown = ({
 };
 
 const History: React.FC = () => {
-  const { theme } = useTheme();
+  const { analyses } = useAnalysis();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [sortBy, setSortBy] = useState('date');
 
-  const filteredHistory = mockHistory
-    .filter(resume => {
+  const filteredHistory = analyses
+    .filter((resume: AnalysisRecord) => {
       const matchesSearch = resume.company.toLowerCase().includes(searchTerm.toLowerCase()) ||
                            resume.position.toLowerCase().includes(searchTerm.toLowerCase());
       const matchesStatus = statusFilter === 'all' || resume.status === statusFilter;
       return matchesSearch && matchesStatus;
     })
-    .sort((a, b) => {
+    .sort((a: AnalysisRecord, b: AnalysisRecord) => {
       if (sortBy === 'date') {
         return new Date(b.date).getTime() - new Date(a.date).getTime();
       } else if (sortBy === 'score') {
@@ -252,11 +179,14 @@ const History: React.FC = () => {
     });
 
   const stats = {
-    total: mockHistory.length,
-    pending: mockHistory.filter(r => r.status === 'pending').length,
-    interviewed: mockHistory.filter(r => r.status === 'interviewed').length,
-    offers: mockHistory.filter(r => r.status === 'offer').length,
-    avgScore: Math.round(mockHistory.reduce((sum, r) => sum + r.score, 0) / mockHistory.length)
+    total: analyses.length,
+    pending: analyses.filter((r: AnalysisRecord) => r.status === 'pending').length,
+    interviewed: analyses.filter((r: AnalysisRecord) => r.status === 'interviewed').length,
+    offers: analyses.filter((r: AnalysisRecord) => r.status === 'offer').length,
+    avgScore: Math.round(
+      analyses.reduce((sum: number, r: AnalysisRecord) => sum + r.score, 0) /
+      (analyses.length || 1)
+    )
   };
 
   return (
@@ -335,7 +265,7 @@ const History: React.FC = () => {
               type="text"
               placeholder="Search companies or positions..."
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
               className={cn(
                 "w-full pl-10 pr-4 py-3 rounded-lg border transition-all duration-300",
                 "bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm",

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { CheckCircle, Target, Zap, Sparkles, FileText, BarChart3 } from 'lucide-react';
+import { Target, Sparkles, FileText, BarChart3 } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from '../components/ThemeToggle';

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Sparkles, TrendingUp, CheckCircle, AlertCircle, Star, Download, Trophy, Target, Zap, Crown, PartyPopper } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
+import { Sparkles, TrendingUp, CheckCircle, Star, Download, Trophy, Target, Zap, PartyPopper } from 'lucide-react';
+import { useAnalysis } from '../contexts/AnalysisContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -85,13 +84,14 @@ const StatCard = ({
 );
 
 const ResultsPage: React.FC = () => {
-  const { theme } = useTheme();
+  const { currentAnalysis } = useAnalysis();
   const [animatedScore, setAnimatedScore] = useState(0);
 
   useEffect(() => {
     // Animate the improvement score
+    if (!currentAnalysis) return;
     let current = 0;
-    const target = 92;
+    const target = currentAnalysis.score;
     const increment = target / 50;
     const timer = setInterval(() => {
       current += increment;
@@ -104,7 +104,15 @@ const ResultsPage: React.FC = () => {
     }, 30);
 
     return () => clearInterval(timer);
-  }, []);
+  }, [currentAnalysis]);
+
+  if (!currentAnalysis) {
+    return (
+      <PageLayout showBackButton backTo="/analyze" backLabel="Back">
+        <div className="p-6 text-center">No analysis selected.</div>
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout showBackButton backTo="/analyze" backLabel="Back" className="px-3 py-3 h-screen flex flex-col">
@@ -150,7 +158,7 @@ const ResultsPage: React.FC = () => {
             >
               <div className="flex items-center justify-center gap-4 mb-3">
                 <div className="text-center">
-                  <div className="text-xl font-bold text-red-500">65%</div>
+                  <div className="text-xl font-bold text-red-500">{currentAnalysis?.beforeScore}%</div>
                   <div className="text-xs text-red-500">Before</div>
                 </div>
                 
@@ -162,34 +170,34 @@ const ResultsPage: React.FC = () => {
                 </div>
               </div>
               
-              <div className="text-xl font-bold text-green-600 dark:text-green-400 mb-1">+27% Better!</div>
+              <div className="text-xl font-bold text-green-600 dark:text-green-400 mb-1">+{currentAnalysis?.improvement}% Better!</div>
               <p className="text-sm text-gray-600 dark:text-gray-300">Your resume now shines brighter than ever</p>
             </motion.div>
 
             {/* Stats Grid - Only 4 key metrics */}
             <div className="grid grid-cols-2 gap-2">
-              <StatCard 
+              <StatCard
                 icon={Target}
-                title="Keyword Match" 
-                value="12/12" 
+                title="Keyword Match"
+                value={`${currentAnalysis?.keywordsMatched}/${currentAnalysis?.totalKeywords}`}
                 color="bg-blue-500"
               />
-              <StatCard 
+              <StatCard
                 icon={Zap}
-                title="Readability" 
-                value="A+" 
+                title="Readability"
+                value={currentAnalysis?.readability}
                 color="bg-purple-500"
               />
-              <StatCard 
+              <StatCard
                 icon={CheckCircle}
-                title="ATS Score" 
-                value="98%" 
+                title="ATS Score"
+                value={`${currentAnalysis?.atsScore}%`}
                 color="bg-green-500"
               />
-              <StatCard 
+              <StatCard
                 icon={Star}
-                title="Impact Factor" 
-                value="9.2/10" 
+                title="Impact Factor"
+                value={`${currentAnalysis?.impactFactor}/10`}
                 color="bg-cyan-500"
               />
             </div>
@@ -241,7 +249,9 @@ const ResultsPage: React.FC = () => {
               <div className="flex items-center justify-between p-3 border-b border-gray-200 dark:border-gray-700">
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-                  <span className="font-bold text-gray-900 dark:text-white text-sm">Software Engineer Resume - Google</span>
+                  <span className="font-bold text-gray-900 dark:text-white text-sm">
+                    {currentAnalysis ? `${currentAnalysis.position} Resume - ${currentAnalysis.company}` : 'Resume'}
+                  </span>
                 </div>
                 <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold px-3 py-1 rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 flex items-center gap-1 text-xs">
                   <Download className="w-3 h-3" />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,7 +10,6 @@ import {
   Lock,
   Download
 } from 'lucide-react';
-import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import PageLayout from '../components/PageLayout';
 import Button from '../components/Button';
@@ -49,41 +48,8 @@ const SettingsSection = ({
   </motion.div>
 );
 
-const ToggleSwitch = ({ 
-  enabled, 
-  onChange, 
-  label, 
-  description 
-}: { 
-  enabled: boolean, 
-  onChange: (enabled: boolean) => void,
-  label: string,
-  description: string
-}) => (
-  <div className="flex items-center justify-between py-3">
-    <div>
-      <div className="font-medium text-zinc-900 dark:text-white">{label}</div>
-      <div className="text-sm text-zinc-600 dark:text-zinc-400">{description}</div>
-    </div>
-    <button
-      onClick={() => onChange(!enabled)}
-      className={cn(
-        "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-        enabled ? "bg-blue-600" : "bg-zinc-300 dark:bg-zinc-600"
-      )}
-    >
-      <span
-        className={cn(
-          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
-          enabled ? "translate-x-6" : "translate-x-1"
-        )}
-      />
-    </button>
-  </div>
-);
 
 const Settings: React.FC = () => {
-  const { theme } = useTheme();
   const [showPassword, setShowPassword] = useState(false);
 
   return (

--- a/src/utils/mockAnalysis.ts
+++ b/src/utils/mockAnalysis.ts
@@ -1,6 +1,33 @@
+import type { AnalysisRecord } from '../contexts/AnalysisContext';
+
 export const getMockMatchScore = () => 76;
 export const getMockKeywords = () => ['Docker', 'Node.js', 'APIs'];
 export const getMockSuggestions = () => [
   'Add a bullet about deploying Docker containers.',
   'Mention working with APIs in your internship.',
-]; 
+];
+
+export const createMockAnalysis = (id: string): AnalysisRecord => {
+  const companies = ['Google', 'Microsoft', 'Apple', 'Amazon', 'Meta', 'Netflix'];
+  const company = companies[Math.floor(Math.random() * companies.length)];
+  const beforeScore = 60 + Math.floor(Math.random() * 10);
+  const improvement = 20 + Math.floor(Math.random() * 15);
+  const score = beforeScore + improvement;
+
+  return {
+    id,
+    company,
+    position: 'Software Engineer',
+    date: new Date().toISOString(),
+    status: 'pending',
+    score,
+    beforeScore,
+    improvement,
+    logo: '📝',
+    keywordsMatched: 12,
+    totalKeywords: 12,
+    readability: 'A',
+    atsScore: 90,
+    impactFactor: 8.5,
+  };
+};


### PR DESCRIPTION
## Summary
- provide new `AnalysisContext` with fake analysis history
- hook analysis context into app
- create random analysis results from `createMockAnalysis`
- push new analysis from Analyze page
- update Results and History pages to use global state
- remove unused variables and imports so build passes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843b7d303308333a3fa8dc3a0f771ba