### PR TITLE
Add performance test page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import History from './pages/History';
 import Settings from './pages/Settings';
 import EditProfile from './pages/EditProfile';
 import Subscription from './pages/Subscription';
+import PerformanceTest from './pages/PerformanceTest';
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
             <Route path="/settings" element={<Settings />} />
             <Route path="/edit-profile" element={<EditProfile />} />
             <Route path="/subscription" element={<Subscription />} />
+            <Route path="/performance" element={<PerformanceTest />} />
           </Routes>
         </Router>
       </FormProvider>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowLeft, Sparkles, ChevronDown, Settings, FileText, LogOut, User, LayoutDashboard, Crown } from 'lucide-react';
+import { ArrowLeft, Sparkles, ChevronDown, Settings, FileText, LogOut, User, LayoutDashboard, Crown, Zap } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { cn } from '../lib/utils';
 import ThemeToggle from './ThemeToggle';
@@ -83,8 +83,8 @@ const Navigation: React.FC<NavigationProps> = ({
         </Link>
 
         {/* Past Resumes Button */}
-        <Link 
-          to="/history" 
+        <Link
+          to="/history"
           className={cn(
             "flex items-center space-x-2 px-3 py-2 rounded-lg transition-all duration-300",
             "bg-white/10 hover:bg-white/20 dark:bg-white/5 dark:hover:bg-white/10",
@@ -95,6 +95,21 @@ const Navigation: React.FC<NavigationProps> = ({
         >
           <FileText className="w-4 h-4" />
           <span>Resumes</span>
+        </Link>
+
+        {/* Performance Test Button */}
+        <Link
+          to="/performance"
+          className={cn(
+            "flex items-center space-x-2 px-3 py-2 rounded-lg transition-all duration-300",
+            "bg-white/10 hover:bg-white/20 dark:bg-white/5 dark:hover:bg-white/10",
+            "text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-white",
+            "border border-white/20 dark:border-white/10 font-medium text-sm",
+            location.pathname === '/performance' && "bg-blue-100/50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-600"
+          )}
+        >
+          <Zap className="w-4 h-4" />
+          <span>Speed Test</span>
         </Link>
 
         {/* Subscription Button */}

--- a/src/pages/PerformanceTest.tsx
+++ b/src/pages/PerformanceTest.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import PageLayout from '../components/PageLayout';
+
+const PerformanceTest: React.FC = () => {
+  const [loadTime, setLoadTime] = useState<number | null>(null);
+  const [score, setScore] = useState<number | null>(null);
+
+  useEffect(() => {
+    const time = performance.now();
+    setLoadTime(Math.round(time));
+    const rating = Math.max(1, 100 - Math.round(time / 50));
+    setScore(rating);
+  }, []);
+
+  return (
+    <PageLayout showBackButton backTo="/" backLabel="Back to Home">
+      <div className="max-w-md mx-auto text-center space-y-4">
+        <h2 className="text-2xl font-bold mb-4">App Performance</h2>
+        {score !== null && (
+          <>
+            <div className="w-full bg-gray-200 dark:bg-gray-800 rounded-full h-4 overflow-hidden">
+              <div
+                className="h-full bg-green-500"
+                style={{ width: `${score}%` }}
+              />
+            </div>
+            <p className="text-lg font-semibold">
+              {score}/100 - {loadTime} ms
+            </p>
+          </>
+        )}
+      </div>
+    </PageLayout>
+  );
+};
+
+export default PerformanceTest;


### PR DESCRIPTION
## Summary
- add a simple `PerformanceTest` page to measure load time
- register the new route
- link to the page from navigation

## Testing
- `npm install`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844516747788333bd6a703cb57b19fc