### PR TITLE
Add tests for theme and utils

### DIFF
--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ThemeToggle from '../ThemeToggle';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+
+describe('ThemeToggle', () => {
+  it('toggles between dark and light themes', () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>
+    );
+
+    const toggle = screen.getByRole('button');
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    fireEvent.click(toggle);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    fireEvent.click(toggle);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn utility', () => {
+  it('merges class names and resolves Tailwind conflicts', () => {
+    const result = cn('p-2 bg-red-500', 'bg-blue-500', 'text-center', { 'font-bold': true });
+    expect(result).toBe('p-2 bg-blue-500 text-center font-bold');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ThemeToggle behavior
- add tests for cn utility classnames

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68449d60356c833398fbda9f0befd0c4